### PR TITLE
Add watchOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ This command will keep only ios version with arm64 slice and ios simulator versi
 |  tvos            |  arm64                     |
 |  tvossimulator   |  arm64, x86\_64            |
 |  macos           |  arm64, i386, x86\_64      |
+|  watchos         |  arm64, arm64\_32, armv7k  |
+|  watchossimulator|  arm64, i386, x86\_64      |

--- a/Sources/CLI/PlatformOptions+ExpressibleByArgument.swift
+++ b/Sources/CLI/PlatformOptions+ExpressibleByArgument.swift
@@ -14,6 +14,8 @@ extension PlatformOptions: ExpressibleByArgument {
         case "tvos": platform = .tvOS
         case "tvossimulator": platform = .tvOSSimulator
         case "macos": platform = .macOS
+        case "watchos": platform = .watchOS
+        case "watchossimulator": platform = .watchOSSimulator
         default: return nil
         }
 

--- a/Sources/XCTrimCore/Types/Architecture.swift
+++ b/Sources/XCTrimCore/Types/Architecture.swift
@@ -3,6 +3,8 @@ public enum Architecture: String, Codable {
     case i386
     case armv7
     case x86_64
+    case arm64_32
+    case armv7k
 }
 
 public extension Architecture {
@@ -20,6 +22,10 @@ public extension Architecture {
             return 2
         case .x86_64:
             return 3
+        case .arm64_32:
+            return 4
+        case .armv7k:
+            return 5
         }
     }
 }

--- a/Sources/XCTrimCore/Types/Library.swift
+++ b/Sources/XCTrimCore/Types/Library.swift
@@ -42,6 +42,10 @@ public extension Library {
             return .tvOS
         case ("macos", nil):
             return .macOS
+        case ("watchos", nil):
+            return .watchOS
+        case ("watchos", "simulator"):
+            return .watchOSSimulator
         default:
             return nil
         }

--- a/Sources/XCTrimCore/Types/Platform.swift
+++ b/Sources/XCTrimCore/Types/Platform.swift
@@ -5,6 +5,8 @@ public enum Platform {
     case tvOS
     case tvOSSimulator
     case macOS
+    case watchOS
+    case watchOSSimulator
 }
 
 extension Platform {
@@ -22,6 +24,10 @@ extension Platform {
             return [.arm64, .x86_64]
         case .macOS:
             return [.arm64, .x86_64, .i386]
+        case .watchOS:
+            return [.arm64, .arm64_32, .armv7k]
+        case .watchOSSimulator:
+            return [.arm64, .i386, .x86_64]
         }
     }
 
@@ -43,6 +49,10 @@ extension Platform {
             return "tvos-\(archStr)-simulator"
         case .macOS:
             return "macos-\(archStr)"
+        case .watchOS:
+            return "watchos-\(archStr)"
+        case .watchOSSimulator:
+            return "watchos-\(archStr)-simulator"
         }
     }
 }


### PR DESCRIPTION
Hello @mstfy!

While working with some prominent third-party libraries like Realm that offer watchOS instruction set libraries, I noticed that xctrim currently doesn't recognize them. This observation motivated me to enhance xctrim by adding support for watchOS.

Changes Made:
watchOS Recognition: The xctrim can now recognize and process frameworks targeting watchOS.

I've tested these changes with several xcframeworks that include watchOS support, and the results were as expected. The tool successfully trimmed unnecessary architectures.

I hope you find these changes valuable. I'm open to feedback and would be happy to make any necessary adjustments.

Thank you for considering this pull request!