### PR TITLE
Fix architectures in plist incorrect

### DIFF
--- a/Sources/XCTrimCore/Types/Library.swift
+++ b/Sources/XCTrimCore/Types/Library.swift
@@ -16,7 +16,8 @@ public struct Library: Codable, Equatable {
     public func edit(with architectures: [Architecture]) -> (Self, Set<Architecture>) {
         guard let platform = platform else { return (self, []) }
 
-        let supportedArchitectures = platform.supportedArchitectures.intersection(architectures)
+        let validatedArchitectures = platform.supportedArchitectures.intersection(architectures)
+        let supportedArchitectures = validatedArchitectures.intersection(self.supportedArchitectures)
         let deletedArchs = self.supportedArchitectures.subtracting(supportedArchitectures)
 
         var copy = self


### PR DESCRIPTION
Hello @mstfy,

I've addressed the [issue](https://github.com/mstfy/xctrim/issues/2) I raised earlier regarding the mismatch between the trimmed architectures and the supportedArchitectures listed in the plist.

Changes Made:
Updated Trimming Logic: Intersect the passed in architectures with `self.supportedArchitectures`.

Thank you for considering this pull request!